### PR TITLE
API integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "react-redux": "^6.0.1",
     "react-scripts": "2.1.3",
     "redux": "^4.1.0",
-    "redux-mock-store": "^1.5.4",
     "redux-thunk": "^2.3.0"
   },
   "scripts": {
@@ -32,6 +31,7 @@
   "devDependencies": {
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.7.1",
-    "react-test-renderer": "^16.7.0"
+    "react-test-renderer": "^16.7.0",
+    "redux-mock-store": "^1.5.4"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     loadTable: () => {
-      dispatch(fetchTable(2));
+      dispatch(fetchTable(7));
     },
   };
 }

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import './App.css';
 import ErrorMessage from './components/ErrorMessage';
 import Loading from './components/Loading';
 import Table from './components/Table';
-import { loadTable } from './slices/tableSlice';
+import { fetchTable } from './slices/tableSlice';
 import { appShape } from './types';
 
 class App extends Component {
@@ -39,7 +39,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     loadTable: () => {
-      dispatch(loadTable(8));
+      dispatch(fetchTable(5));
     },
   };
 }

--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     loadTable: () => {
-      dispatch(fetchTable(5));
+      dispatch(fetchTable(2));
     },
   };
 }

--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     loadTable: () => {
-      dispatch(fetchTable(7));
+      dispatch(fetchTable(1));
     },
   };
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,25 +1,54 @@
+import { mount } from 'enzyme';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import App from './App';
+import ErrorMessage from './components/ErrorMessage';
+import Loading from './components/Loading';
+import Table from './components/Table';
+import data from './data/table-1';
 
-it('renders without crashing', () => {
-  const mockStore = configureStore([thunk]);
+const mockStore = configureStore([thunk]);
+
+function mountApp(table) {
   const store = mockStore({
-    table: {
-      isLoading: false,
-      error: null,
-      table: null,
-    },
+    table,
   });
   const div = document.createElement('div');
-  ReactDOM.render(
+  return mount(
     <Provider store={store}>
       <App/>
     </Provider>,
     div
   );
-  ReactDOM.unmountComponentAtNode(div);
+}
+
+describe('App', () => {
+  it('renders Loading', () => {
+    const wrapper = mountApp({
+      isLoading: true,
+    });
+    expect(wrapper.find(Loading).length).toEqual(1);
+    expect(wrapper.find(ErrorMessage).length).toEqual(0);
+    expect(wrapper.find(Table).length).toEqual(0);
+  });
+
+  it('renders ErrorMessage', () => {
+    const wrapper = mountApp({
+      error: 'An error occurred.',
+    });
+    expect(wrapper.find(Loading).length).toEqual(0);
+    expect(wrapper.find(ErrorMessage).length).toEqual(1);
+    expect(wrapper.find(Table).length).toEqual(0);
+  });
+
+  it('renders Table', () => {
+    const wrapper = mountApp({
+      table: data,
+    });
+    expect(wrapper.find(Loading).length).toEqual(0);
+    expect(wrapper.find(ErrorMessage).length).toEqual(0);
+    expect(wrapper.find(Table).length).toEqual(1);
+  });
 });

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -1,13 +1,13 @@
 .Card {
-  position: absolute;
+  position: relative;
   width: 70px;
+  float: left;
+  margin-right: 5px;
   top: -95px;
 }
 
-.Card:nth-child(1) { left: 0; }
-.Card:nth-child(2) { left: 75px; }
-
-.Table-omaha .Card:nth-child(1) { left: 0; }
-.Table-omaha .Card:nth-child(2) { left: 25px; }
-.Table-omaha .Card:nth-child(3) { left: 50px; }
-.Table-omaha .Card:nth-child(4) { left: 75px; }
+.Table-omaha .Seat .Card { position: absolute; }
+.Table-omaha .Seat .Card:nth-child(1) { left: 0; }
+.Table-omaha .Seat .Card:nth-child(2) { left: 25px; }
+.Table-omaha .Seat .Card:nth-child(3) { left: 50px; }
+.Table-omaha .Seat .Card:nth-child(4) { left: 75px; }

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -1,7 +1,13 @@
 .Card {
-  position: relative;
+  position: absolute;
   width: 70px;
-  float: left;
-  margin-right: 5px;
   top: -95px;
 }
+
+.Card:nth-child(1) { left: 0; }
+.Card:nth-child(2) { left: 75px; }
+
+.Table-omaha .Card:nth-child(1) { left: 0; }
+.Table-omaha .Card:nth-child(2) { left: 25px; }
+.Table-omaha .Card:nth-child(3) { left: 50px; }
+.Table-omaha .Card:nth-child(4) { left: 75px; }

--- a/src/components/Seat/Seat.css
+++ b/src/components/Seat/Seat.css
@@ -28,3 +28,8 @@
 .Seats-6 .Seat-3 { left: -200px; top: 300px; }
 .Seats-6 .Seat-4 { left: -470px; top: 50px; }
 .Seats-6 .Seat-5 { left: -200px; top: -250px; }
+
+.Seats-4 .Seat-0 { left: 200px; top: -250px; }
+.Seats-4 .Seat-1 { left: 200px; top: 300px; }
+.Seats-4 .Seat-2 { left: -200px; top: 300px; }
+.Seats-4 .Seat-3 { left: -200px; top: -250px; }

--- a/src/components/Seat/Seat.js
+++ b/src/components/Seat/Seat.js
@@ -7,7 +7,7 @@ import Cards from '../Cards';
 import Chips from '../Chips';
 import './Seat.css';
 
-const Seat = ({ id, state, username, chips, cards, bet }) => (
+const Seat = ({ id, state, username, chips, cards, bet, fold }) => (
   <div className={cx('Seat', `Seat-${id}`)}>
     {
       username ? (
@@ -22,12 +22,10 @@ const Seat = ({ id, state, username, chips, cards, bet }) => (
       )
     }
     <Chips amount={bet} />
-    <Cards values={cards} />
+    { !fold && <Cards values={cards} /> }
   </div>
 );
 
-Seat.propTypes = {
-  ...seatProps,
-}
+Seat.propTypes = seatProps.isRequired;
 
 export default Seat;

--- a/src/components/Seat/Seat.js
+++ b/src/components/Seat/Seat.js
@@ -7,13 +7,13 @@ import Cards from '../Cards';
 import Chips from '../Chips';
 import './Seat.css';
 
-const Seat = ({ id, state, username, chips, cards, bet, fold }) => (
+const Seat = ({ id, state, username, chips, cards, bet, fold, allIn }) => (
   <div className={cx('Seat', `Seat-${id}`)}>
     {
       username ? (
         <div className="nameplate">
           <div className="username">{username}</div>
-          <div className="chips">{(bet > 0 && chips < 0) ? 'All-In' : numberFormatter.format(chips)}</div>
+          <div className="chips">{allIn ? 'All-In' : numberFormatter.format(chips)}</div>
         </div>
       ) : (
         <div className="nameplate available">

--- a/src/components/Seat/Seat.test.js
+++ b/src/components/Seat/Seat.test.js
@@ -45,7 +45,7 @@ describe('Seats', () => {
     });
   });
 
-  describe('unoccuped', () => {
+  describe('unoccupied', () => {
     it('shows seat available', () => {
       component = shallow(<Seat id={0} state="available" />);
       expect(component.find('.available').text()).toEqual('Seat Available');

--- a/src/components/Seat/Seat.test.js
+++ b/src/components/Seat/Seat.test.js
@@ -24,8 +24,8 @@ describe('Seats', () => {
       expect(component.find('.chips').text()).toEqual('12345')
     });
 
-    xit('shows All-In when the player has bet all of their chips', () => {
-      component = shallow(<Seat {...props} chips={0} />);
+    it('shows All-In when the player has bet all of their chips', () => {
+      component = shallow(<Seat {...props} allIn={true} />);
       expect(component.find('.chips').text()).toEqual('All-In')
     });
 
@@ -37,7 +37,12 @@ describe('Seats', () => {
     it('shows the hole cards', () => {
       component = shallow(<Seat {...props} />);
       expect(component.find(Cards).props()).toEqual({ values: ['Ac', 'As'] });
-    })
+    });
+
+    it('hides cards if folded', () => {
+      component = shallow(<Seat {...props} fold={true} />);
+      expect(component.find(Cards).length).toEqual(0);
+    });
   });
 
   describe('unoccuped', () => {

--- a/src/components/Seats/Seats.js
+++ b/src/components/Seats/Seats.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import find from 'lodash/find';
 import cx from 'classnames';
 
 import { seatShape } from '../../types';
@@ -9,7 +8,7 @@ import Seat from '../Seat';
 
 const Seats = ({ seats, players }) => (
   <div className={cx('Seats', `Seats-${seats.length}`)}>
-    { seats.map((seat) => <Seat key={seat.id} {...seat} {...find(players, { seatId: seat.id })} />) }
+    { seats.map((seat) => <Seat key={seat.id} {...seat} />) }
   </div>
 );
 

--- a/src/components/Seats/Seats.js
+++ b/src/components/Seats/Seats.js
@@ -6,7 +6,7 @@ import { seatShape } from '../../types';
 
 import Seat from '../Seat';
 
-const Seats = ({ seats, players }) => (
+const Seats = ({ seats }) => (
   <div className={cx('Seats', `Seats-${seats.length}`)}>
     { seats.map((seat) => <Seat key={seat.id} {...seat} />) }
   </div>

--- a/src/components/Seats/Seats.test.js
+++ b/src/components/Seats/Seats.test.js
@@ -9,12 +9,14 @@ describe('Seats', () => {
   let component;
 
   it('renders a Seat for each seat at the table', () => {
-    component = shallow(<Seats seats={data.seats} players={data.currentHand.players} />);
+    component = shallow(<Seats seats={data.seats} />);
     expect(component.find(Seat).length).toEqual(6);
   });
 
-  it('combines seat and player data for the seat', () => {
-    component = shallow(<Seats seats={data.seats} players={data.currentHand.players} />);
+  // merging data should be done in another layer of
+  // the application, not in a view component
+  xit('combines seat and player data for the seat', () => {
+    component = shallow(<Seats seats={data.seats} />);
     const seat4 = component.find(Seat).at(4);
     expect(seat4.props().bet).toEqual(20);
   });

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -11,7 +11,7 @@ import './Table.css';
 const Table = ({ table }) => (
   <div className={cx('Table', `Table-${table.game}`)}>
     <div>
-      <Seats seats={table.seats} players={table.currentHand && table.currentHand.players} />
+      <Seats seats={table.seats} />
       { table.currentHand && <Cards values={table.currentHand.communityCards} /> }
       { table.currentHand && <Pots pots={table.currentHand.pots} /> }
     </div>

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -10,9 +10,9 @@ import './Table.css';
 const Table = ({ table }) => (
   <div className="Table">
     <div>
-      <Seats seats={table.seats} players={table.currentHand.players} />
-      <Cards values={table.currentHand.communityCards} />
-      <Pots pots={table.currentHand.pots} />
+      <Seats seats={table.seats} players={table.currentHand && table.currentHand.players} />
+      { table.currentHand && <Cards values={table.currentHand.communityCards} /> }
+      { table.currentHand && <Pots pots={table.currentHand.pots} /> }
     </div>
   </div>
 );

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import cx from 'classnames';
 import { tableShape } from '../../types';
 
 import Seats from '../Seats';
@@ -8,7 +9,7 @@ import Pots from '../Pots';
 import './Table.css';
 
 const Table = ({ table }) => (
-  <div className="Table">
+  <div className={cx('Table', `Table-${table.game}`)}>
     <div>
       <Seats seats={table.seats} players={table.currentHand && table.currentHand.players} />
       { table.currentHand && <Cards values={table.currentHand.communityCards} /> }

--- a/src/components/Table/Table.test.js
+++ b/src/components/Table/Table.test.js
@@ -10,18 +10,22 @@ import data from '../../data/table-1';
 describe('Table', () => {
   let component;
 
-  it('renders Seats', () => {
+  it('renders Table with Seats, Pots, Cards, and correct class name', () => {
     component = shallow(<Table table={data} />);
     expect(component.find(Seats).length).toEqual(1);
-  });
-
-  it('renders Pots', () => {
-    component = shallow(<Table table={data} />);
     expect(component.find(Pots).length).toEqual(1);
+    expect(component.find(Cards).length).toEqual(1);
+    expect(component.hasClass('Table-holdem')).toEqual(true);
   });
 
-  it('renders Cards', () => {
-    component = shallow(<Table table={data} />);
-    expect(component.find(Cards).length).toEqual(1);
+  it('renders Table without currentHand', () => {
+    const dataWithoutCurrentHand = {
+      ...data,
+      currentHand: undefined,
+    };
+    component = shallow(<Table table={dataWithoutCurrentHand} />);
+    expect(component.find(Seats).length).toEqual(1);
+    expect(component.find(Pots).length).toEqual(0);
+    expect(component.find(Cards).length).toEqual(0);
   });
 });

--- a/src/slices/tableSlice.js
+++ b/src/slices/tableSlice.js
@@ -67,7 +67,7 @@ function parseTable(table) {
 
   table.currentHand.players.forEach(player => {
     const seat = table.seats.find(seat => seat.id === player.seatId);
-    const allIn = seat.chips === 0 && table.currentHand.pots.some(pot => pot.seatIds.includes(player.seatId));
+    const allIn = seat.chips === 0 && (player.bet > 0 || table.currentHand.pots.some(pot => pot.seatIds.includes(player.seatId)));
     seat.allIn = allIn;
     seat.bet = player.bet;
     seat.cards = player.cards;

--- a/src/slices/tableSlice.js
+++ b/src/slices/tableSlice.js
@@ -51,7 +51,7 @@ export function loadComplete(table) {
   };
 }
 
-export function loadTable(id) {
+export function fetchTable(id) {
   return (dispatch) => {
     dispatch(load());
     return axios.get(`https://storage.googleapis.com/replaypoker-dummy-api/tables/${id}.json`)

--- a/src/slices/tableSlice.js
+++ b/src/slices/tableSlice.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
-const LOAD = 'table/load';
-const LOAD_COMPLETE = 'table/loadComplete';
-const LOAD_ERROR = 'table/loadError';
+const LOAD = 'poker-table/table/LOAD';
+const LOAD_COMPLETE = 'poker-table/table/LOAD_COMPLETE';
+const LOAD_ERROR = 'poker-table/table/LOAD_ERROR';
 
 export const initialState = {
   isLoading: false,

--- a/src/slices/tableSlice.js
+++ b/src/slices/tableSlice.js
@@ -73,6 +73,7 @@ function parseTable(table) {
     seat.allIn = allIn;
     seat.bet = player.bet;
     seat.cards = player.cards;
+    seat.fold = player.fold;
     if (player.cards) {
       allCards.push(...player.cards);
     }

--- a/src/slices/tableSlice.js
+++ b/src/slices/tableSlice.js
@@ -69,6 +69,13 @@ function parseTable(table) {
         allIn: seat.chips === 0 && table.currentHand.pots.some(pot => pot.seatIds.includes(player.seatId)),
       };
     });
+    table.seats = table.seats.map(seat => {
+      const player = table.currentHand.players.find(player => player.seatId === seat.id);
+      return {
+        ...seat,
+        ...player,
+      };
+    });
   }
   return table;
 }

--- a/src/slices/tableSlice.js
+++ b/src/slices/tableSlice.js
@@ -65,12 +65,22 @@ function parseTable(table) {
     return table;
   }
 
+  const allCards = [...table.currentHand.communityCards];
+
   table.currentHand.players.forEach(player => {
     const seat = table.seats.find(seat => seat.id === player.seatId);
     const allIn = seat.chips === 0 && (player.bet > 0 || table.currentHand.pots.some(pot => pot.seatIds.includes(player.seatId)));
     seat.allIn = allIn;
     seat.bet = player.bet;
     seat.cards = player.cards;
+    allCards.push(...player.cards);
   });
+
+  const allVisibleCards = allCards.filter(card => card !== 'X');
+  const uniqueCards = new Set(allVisibleCards);
+  if (allVisibleCards.length !== uniqueCards.size) {
+    throw new Error('Invalid game state!');
+  }
+
   return table;
 }

--- a/src/slices/tableSlice.js
+++ b/src/slices/tableSlice.js
@@ -61,21 +61,16 @@ export function fetchTable(id) {
 }
 
 function parseTable(table) {
-  if (table.currentHand) {
-    table.currentHand.players = table.currentHand.players.map(player => {
-      const seat = table.seats.find(seat => seat.id === player.seatId);
-      return {
-        ...player,
-        allIn: seat.chips === 0 && table.currentHand.pots.some(pot => pot.seatIds.includes(player.seatId)),
-      };
-    });
-    table.seats = table.seats.map(seat => {
-      const player = table.currentHand.players.find(player => player.seatId === seat.id);
-      return {
-        ...seat,
-        ...player,
-      };
-    });
+  if (!table.currentHand) {
+    return table;
   }
+
+  table.currentHand.players.forEach(player => {
+    const seat = table.seats.find(seat => seat.id === player.seatId);
+    const allIn = seat.chips === 0 && table.currentHand.pots.some(pot => pot.seatIds.includes(player.seatId));
+    seat.allIn = allIn;
+    seat.bet = player.bet;
+    seat.cards = player.cards;
+  });
   return table;
 }

--- a/src/slices/tableSlice.js
+++ b/src/slices/tableSlice.js
@@ -55,7 +55,20 @@ export function fetchTable(id) {
   return (dispatch) => {
     dispatch(load());
     return axios.get(`https://storage.googleapis.com/replaypoker-dummy-api/tables/${id}.json`)
-      .then(response => dispatch(loadComplete(response.data)))
+      .then(response => dispatch(loadComplete(parseTable(response.data))))
       .catch(error => dispatch(loadError(error.message)));
   }
+}
+
+function parseTable(table) {
+  if (table.currentHand) {
+    table.currentHand.players = table.currentHand.players.map(player => {
+      const seat = table.seats.find(seat => seat.id === player.seatId);
+      return {
+        ...player,
+        allIn: seat.chips === 0 && table.currentHand.pots.some(pot => pot.seatIds.includes(player.seatId)),
+      };
+    });
+  }
+  return table;
 }

--- a/src/slices/tableSlice.js
+++ b/src/slices/tableSlice.js
@@ -73,7 +73,9 @@ function parseTable(table) {
     seat.allIn = allIn;
     seat.bet = player.bet;
     seat.cards = player.cards;
-    allCards.push(...player.cards);
+    if (player.cards) {
+      allCards.push(...player.cards);
+    }
   });
 
   const allVisibleCards = allCards.filter(card => card !== 'X');

--- a/src/slices/tableSlice.test.js
+++ b/src/slices/tableSlice.test.js
@@ -1,4 +1,62 @@
-import tableReducer, { initialState, load, loadComplete, loadError } from './tableSlice';
+import axios from 'axios';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import tableReducer, { fetchTable, initialState, load, loadComplete, loadError } from './tableSlice';
+
+const data = {
+  id: 1,
+  state: 'open',
+  game: 'holdem',
+  blinds: {
+    small: 10,
+    big: 20,
+  },
+  seats: [
+    { id: 0, state: 'available' },
+    { id: 1, state: 'occupied', username: 'MCA', chips: 0 },
+    { id: 2, state: 'available' },
+    { id: 3, state: 'occupied', username: 'Mike D', chips: 57465 },
+    { id: 4, state: 'occupied', username: 'Ad-Rock', chips: 62860 },
+    { id: 5, state: 'available' },
+  ],
+  currentHand: {
+    id: 56829,
+    communityCards: [],
+    players: [
+      { seatId: 1, cards: ['X', 'X'], bet: 0 },
+      { seatId: 3, cards: ['X', 'X'], bet: 10 },
+      { seatId: 4, cards: ['Ac', '9d'], bet: 20 },
+    ],
+    pots: [
+      { chips: 100, seatIds: [ 1 ] },
+    ],
+  },
+};
+
+jest.mock('axios');
+
+const mockStore = configureMockStore([thunk]);
+
+describe('fetchTable', () => {
+  it('should fetch table data and parse it', () => {
+    axios.get.mockImplementationOnce(() => Promise.resolve({ data }));
+
+    const parsedData = { ...data};
+    parsedData.seats[1].player = { seatId: 1, bet: 0, cards: ['X', 'X'], allIn: true };
+    parsedData.seats[3].player = { seatId: 3, bet: 10, cards: ['X', 'X'] };
+    parsedData.seats[4].player = { seatId: 4, bet: 20, cards: ['Ac', '9d'] };
+
+    const expectedActions = [
+      { type: 'poker-table/table/LOAD' },
+      { type: 'poker-table/table/LOAD_COMPLETE', payload: parsedData },
+    ];
+
+    const store = mockStore({});
+    return store.dispatch(fetchTable(1)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});
 
 describe('tableReducer', () => {
   it('should start loading table data', () => {

--- a/src/slices/tableSlice.test.js
+++ b/src/slices/tableSlice.test.js
@@ -57,6 +57,22 @@ describe('fetchTable', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+
+  it('should throw error if data contains duplicate cards', () => {
+    const data = createMockData();
+    data.currentHand.communityCards = ['Ac', '9c'];
+    axios.get.mockImplementationOnce(() => Promise.resolve({ data }));
+
+    const expectedActions = [
+      { type: 'poker-table/table/LOAD' },
+      { type: 'poker-table/table/LOAD_ERROR', payload: 'Invalid game state!' },
+    ];
+
+    const store = mockStore({});
+    return store.dispatch(fetchTable(1)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
 });
 
 describe('tableReducer', () => {

--- a/src/slices/tableSlice.test.js
+++ b/src/slices/tableSlice.test.js
@@ -15,7 +15,7 @@ const data = {
     { id: 0, state: 'available' },
     { id: 1, state: 'occupied', username: 'MCA', chips: 0 },
     { id: 2, state: 'available' },
-    { id: 3, state: 'occupied', username: 'Mike D', chips: 57465 },
+    { id: 3, state: 'occupied', username: 'Mike D', chips: 0 },
     { id: 4, state: 'occupied', username: 'Ad-Rock', chips: 62860 },
     { id: 5, state: 'available' },
   ],
@@ -41,10 +41,17 @@ describe('fetchTable', () => {
   it('should fetch table data and parse it', () => {
     axios.get.mockImplementationOnce(() => Promise.resolve({ data }));
 
-    const parsedData = { ...data};
-    parsedData.seats[1].player = { seatId: 1, bet: 0, cards: ['X', 'X'], allIn: true };
-    parsedData.seats[3].player = { seatId: 3, bet: 10, cards: ['X', 'X'] };
-    parsedData.seats[4].player = { seatId: 4, bet: 20, cards: ['Ac', '9d'] };
+    const parsedData = {
+      ...data,
+      seats: [
+        { id: 0, state: 'available' },
+        { id: 1, state: 'occupied', username: 'MCA', chips: 0, allIn: true, bet: 0, cards: ['X', 'X'] },
+        { id: 2, state: 'available' },
+        { id: 3, state: 'occupied', username: 'Mike D', chips: 0, allIn: true, bet: 10, cards: ['X', 'X'] },
+        { id: 4, state: 'occupied', username: 'Ad-Rock', chips: 62860, allIn: false, bet: 20, cards: ['Ac', '9d'] },
+        { id: 5, state: 'available' },
+      ]
+    };
 
     const expectedActions = [
       { type: 'poker-table/table/LOAD' },

--- a/src/slices/tableSlice.test.js
+++ b/src/slices/tableSlice.test.js
@@ -3,7 +3,9 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import tableReducer, { fetchTable, initialState, load, loadComplete, loadError } from './tableSlice';
 
-const data = {
+jest.mock('axios');
+
+const createMockData = () => ({
   id: 1,
   state: 'open',
   game: 'holdem',
@@ -31,27 +33,19 @@ const data = {
       { chips: 100, seatIds: [ 1 ] },
     ],
   },
-};
-
-jest.mock('axios');
+});
 
 const mockStore = configureMockStore([thunk]);
 
 describe('fetchTable', () => {
   it('should fetch table data and parse it', () => {
+    const data = createMockData();
     axios.get.mockImplementationOnce(() => Promise.resolve({ data }));
 
-    const parsedData = {
-      ...data,
-      seats: [
-        { id: 0, state: 'available' },
-        { id: 1, state: 'occupied', username: 'MCA', chips: 0, allIn: true, bet: 0, cards: ['X', 'X'] },
-        { id: 2, state: 'available' },
-        { id: 3, state: 'occupied', username: 'Mike D', chips: 0, allIn: true, bet: 10, cards: ['X', 'X'] },
-        { id: 4, state: 'occupied', username: 'Ad-Rock', chips: 62860, allIn: false, bet: 20, cards: ['Ac', '9d'] },
-        { id: 5, state: 'available' },
-      ]
-    };
+    const parsedData = createMockData();
+    parsedData.seats[1] = { id: 1, state: 'occupied', username: 'MCA', chips: 0, allIn: true, bet: 0, cards: ['X', 'X'] };
+    parsedData.seats[3] = { id: 3, state: 'occupied', username: 'Mike D', chips: 0, allIn: true, bet: 10, cards: ['X', 'X'] };
+    parsedData.seats[4] = { id: 4, state: 'occupied', username: 'Ad-Rock', chips: 62860, allIn: false, bet: 20, cards: ['Ac', '9d'] };
 
     const expectedActions = [
       { type: 'poker-table/table/LOAD' },

--- a/src/types.js
+++ b/src/types.js
@@ -14,6 +14,7 @@ export const seatProps = {
   state: PropTypes.oneOf(['available', 'occupied']).isRequired,
   username: PropTypes.string,
   chips: PropTypes.number,
+  fold: PropTypes.bool,
 };
 export const seatShape = PropTypes.shape(seatProps);
 

--- a/src/types.js
+++ b/src/types.js
@@ -32,7 +32,7 @@ const handShape = PropTypes.shape({
 export const tableShape = PropTypes.shape({
   id: PropTypes.number.isRequired,
   state: PropTypes.oneOf(['open', 'closed']).isRequired,
-  game: PropTypes.oneOf(['holdem', 'omaha', 'royal']).isRequired,
+  game: PropTypes.oneOf(['holdem', 'omaha', 'omaha_hilo', 'royal']).isRequired,
   blinds: PropTypes.shape({
     small: PropTypes.number.isRequired,
     big: PropTypes.number.isRequired,

--- a/src/types.js
+++ b/src/types.js
@@ -15,6 +15,7 @@ export const seatProps = {
   username: PropTypes.string,
   chips: PropTypes.number,
   fold: PropTypes.bool,
+  allIn: PropTypes.bool,
 };
 export const seatShape = PropTypes.shape(seatProps);
 

--- a/src/types.js
+++ b/src/types.js
@@ -6,7 +6,7 @@ const cardType = PropTypes.string;
 const playerShape = PropTypes.shape({
   seatId: PropTypes.number.isRequired,
   bet: PropTypes.number.isRequired,
-  cards: PropTypes.arrayOf(cardType).isRequired,
+  cards: PropTypes.arrayOf(cardType),
 });
 
 export const seatProps = {

--- a/src/types.js
+++ b/src/types.js
@@ -7,6 +7,7 @@ const playerShape = PropTypes.shape({
   seatId: PropTypes.number.isRequired,
   bet: PropTypes.number.isRequired,
   cards: PropTypes.arrayOf(cardType),
+  fold: PropTypes.bool,
 });
 
 export const seatProps = {
@@ -14,8 +15,12 @@ export const seatProps = {
   state: PropTypes.oneOf(['available', 'occupied']).isRequired,
   username: PropTypes.string,
   chips: PropTypes.number,
-  fold: PropTypes.bool,
+  // field computed when API data is loaded
   allIn: PropTypes.bool,
+  // merged fields from player
+  bet: PropTypes.number,
+  cards: PropTypes.arrayOf(cardType),
+  fold: PropTypes.bool,
 };
 export const seatShape = PropTypes.shape(seatProps);
 


### PR DESCRIPTION
- Adds CSS for 4 cards in a seat.
- Adds CSS for 4 seats in a table.
- Adds `omaha_hilo` in game type enum.
- Hides cards if player has folded.
- Checks for non-null `currentHand` in `Table`.
- Creates `parseTable` function in `tableSlice`, responsible for:
  - Merging `player` data (`bet`, `cards`, `fold`) into `seat` data: this removes data logic from the `Seats` component and keeps it centralized in the `tableSlice`. Also, it allows us to (possibly) remove the `lodash/find` dependency.
  - Computing an `allIn` boolean flag for each `seat`: this removes logic from the `Seat` component. Now it also checks for a player's participation in `currentHand.pots`.
  - Validating for duplicate cards throughout community and player cards: I asked Rodrigo and he suggested removing the duplicate card. But that raises another question, where should the duplicate card be removed from? I implemented an error message for now.